### PR TITLE
Remove quotes surrounding changed files

### DIFF
--- a/plugin/compare.go
+++ b/plugin/compare.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -83,7 +84,7 @@ func (c *compare) getChanged() error {
 	for _, f := range fileStats {
 		if f.Name != "" {
 			fmt.Print(f.String())
-			changed = append(changed, f.Name)
+			changed = append(changed, strings.Trim(f.Name, "\""))
 		}
 	}
 


### PR DESCRIPTION
The normal `git diff` output gives a list of changed files:
```
$ git diff --name-only c8323a8a5b0d438ef651ad427f0b88d5828f7248..134a982e89441825f1219a91517e6bc857e6d988
changelog/unreleased/40155
core/js/sharedialogview.js
```

But if a file name has special characters then it is surrounded by double-quotes:
```
$ git diff --name-only 46de3c5cf386ba5c99e3309bad12655dbb74c073..a1bdb4f87c09f4484b3a6be32ea18fbda65db5c7
"tests/acceptance/fixtures/\340\244\270\340\244\277\340\244\256\340\244\270\340\244\277\340\244\256\340\245\207-\340\244\252\340\244\276\340\244\250\340\245\200.png"
```

Examples are from `ownclud/core`

I noticed this because the acceptance tests were all skipped in https://github.com/owncloud/core/pull/40200 even though a file in `tests/acceptance` had changed.

The regex comparison is looking for files with paths starting with `tests/acceptance` but this starts with `"tests/acceptance`

This PR adds code to trim off the double-quotes at the end of any entries in the list of changed files. That will allow them to match the typical regexes that are used, that start with some "ordinary-named" path.

Note: if someone really wants to exactly match some path+file that has strange characters in the name, then they will still have to do some hard work to find the string that `git diff` produces and make sure that their regex will match it - but that is a different challenge.